### PR TITLE
Changes to support rotor & DLC integration with WEIS

### DIFF
--- a/raft/helpers.py
+++ b/raft/helpers.py
@@ -1,11 +1,5 @@
 import os
-import os.path as osp
-import sys
-import yaml
-import moorpy as mp
 import numpy as np
-import matplotlib.pyplot as plt
-from matplotlib import cm
 import wisdem.inputs as sch    # used for loading turbine YAML and using WISDEM validation process
 from wisdem.commonse.utilities import arc_length
 
@@ -29,7 +23,7 @@ class Env:
 
 
 # ------------------------ misc helper functions -------------------------------
-
+# GB: If it helps, there are np.rad2deg and np.deg2rad functions
 def rad2deg(rad):
     return rad*57.29577951308232
 def deg2rad(deg):

--- a/raft/omdao_raft.py
+++ b/raft/omdao_raft.py
@@ -133,7 +133,11 @@ class RAFT_OMDAO(om.ExplicitComponent):
         self.add_input("shear_exp", val=0.2, desc="Shear exponent of the wind.")
 
         # DLCs
-        self.add_discrete_input('raft_dlcs', val=[[]]*n_cases, desc='DLC case table for RAFT')
+        self.add_discrete_input('raft_dlcs', val=[[]]*n_cases, desc='DLC case table for RAFT with each row a new case and headings described by the keys')
+        self.add_discrete_input('raft_dlcs_keys', val=['wind_speed', 'wind_heading', 'turbulence',
+                                                       'turbine_status', 'yaw_misalign', 'wave_spectrum',
+                                                       'wave_period', 'wave_height', 'wave_heading'],
+                                desc='DLC case table column headings')
         
         # member inputs
         for i in range(1, nmembers + 1):
@@ -512,9 +516,7 @@ class RAFT_OMDAO(om.ExplicitComponent):
 
         # DLCs
         design['cases'] = {}
-        design['cases']['keys'] = ['wind_speed', 'wind_heading', 'turbulence',
-                                   'turbine_status', 'yaw_misalign', 'wave_spectrum',
-                                   'wave_period', 'wave_height', 'wave_heading']
+        design['cases']['keys'] = discrete_inputs['raft_dlcs_keys']
         design['cases']['data'] = discrete_inputs['raft_dlcs']
 
         # create and run the model

--- a/raft/omdao_raft.py
+++ b/raft/omdao_raft.py
@@ -23,7 +23,16 @@ class RAFT_OMDAO(om.ExplicitComponent):
 
         turbine_opt = self.options['turbine_options']
         turbine_npts = turbine_opt['npts']
-
+        n_gain = turbine_opt['PC_GS_n']
+        n_span = turbine_opt['n_span']
+        n_aoa = turbine_opt['n_aoa']
+        n_Re = turbine_opt['n_Re']
+        n_tab = turbine_opt['n_tab']
+        n_pc = turbine_opt['n_pc']
+        n_af = turbine_opt['n_af']
+        af_used_names = turbine_opt['af_used_names']
+        n_af_span = len(af_used_names)
+        
         members_opt = self.options['member_options']
         nmembers = members_opt['nmembers']
         member_npts = members_opt['npts']
@@ -51,6 +60,7 @@ class RAFT_OMDAO(om.ExplicitComponent):
         self.add_input('turbine_xCG_RNA', val=0.0, units='m', desc='x location of RNA center of mass')
         
         self.add_input('turbine_hHub', val=0.0, units='m', desc='Hub height above water line')
+        self.add_input('turbine_overhang', val=0.0, units='m', desc='Overhang of rotor apex from tower centerline (parallel to ground)')
         self.add_input('turbine_Fthrust', val=0.0, units='N', desc='Temporary thrust force to use')
         self.add_input('turbine_yaw_stiffness', val=0.0, units='N*m', desc='Additional yaw stiffness to apply if not modeling crowfoot in the mooring system')
         # tower inputs
@@ -84,12 +94,43 @@ class RAFT_OMDAO(om.ExplicitComponent):
         self.add_input('turbine_tower_rho_shell', val=0.0, units='kg/m**3', desc='Material density')
 
         # control inputs
-        self.add_input('rotor_PC_GS_angles',     val=np.zeros(turbine_opt['PC_GS_n']),   units='rad',        desc='Gain-schedule table: pitch angles')
-        self.add_input('rotor_PC_GS_Kp',         val=np.zeros(turbine_opt['PC_GS_n']),   units='s',          desc='Gain-schedule table: pitch controller kp gains')
-        self.add_input('rotor_PC_GS_Ki',         val=np.zeros(turbine_opt['PC_GS_n']),                       desc='Gain-schedule table: pitch controller ki gains')
+        self.add_input('rotor_PC_GS_angles',     val=np.zeros(n_gain),   units='rad',        desc='Gain-schedule table: pitch angles')
+        self.add_input('rotor_PC_GS_Kp',         val=np.zeros(n_gain),   units='s',          desc='Gain-schedule table: pitch controller kp gains')
+        self.add_input('rotor_PC_GS_Ki',         val=np.zeros(n_gain),                       desc='Gain-schedule table: pitch controller ki gains')
         self.add_input('rotor_Fl_Kp',            val=0.0,                        desc='Floating feedback gain')
         self.add_input('rotor_inertia',          val=0.0,    units='kg*m**2',    desc='Rotor inertia')
-
+        self.add_input('rotor_TC_VS_Kp',         val=np.zeros(n_gain),   units='s',          desc='Gain-schedule table: torque controller kp gains')
+        self.add_input('rotor_TC_VS_Ki',         val=np.zeros(n_gain),                       desc='Gain-schedule table: torque controller ki gains')
+        # Blade and rotor inputs
+        self.add_discrete_input('nBlades', val=3, desc='number of blades')
+        self.add_input('tilt', val=0.0, units='deg', desc='shaft upward tilt angle relative to horizontal')
+        self.add_input('precone', val=0.0, units='deg', desc='hub precone angle')
+        self.add_input('wind_reference_height', val=0.0, units='m', desc='hub height used for power-law wind profile. U = Uref*(z/hubHt)**shearExp')
+        self.add_input('hub_radius', val=0.0, units='m', desc='radius of hub')
+        self.add_input("gear_ratio", val=1.0, desc="Total gear ratio of drivetrain (use 1.0 for direct)")
+        self.add_input('blade_r', val=np.zeros(n_span), units='m', desc='locations defining the blade along z-axis of blade coordinate system')
+        self.add_input('blade_chord', val=np.zeros(n_span), units='m', desc='corresponding chord length at each section')
+        self.add_input('blade_theta', val=np.zeros(n_span), units='deg', desc='corresponding :ref:`twist angle <blade_airfoil_coord>` at each section---positive twist decreases angle of attack')
+        self.add_input('blade_Rtip', val=0.0, units='m', desc='radius of blade tip')
+        self.add_input('blade_precurve', val=np.zeros(n_span), units='m', desc='location of blade pitch axis in x-direction of :ref:`blade coordinate system <azimuth_blade_coord>`')
+        self.add_input('blade_precurveTip', val=0.0, units='m', desc='location of blade pitch axis in x-direction at the tip (analogous to Rtip)')
+        self.add_input('blade_presweep', val=np.zeros(n_span), units='m', desc='location of blade pitch axis in y-direction of :ref:`blade coordinate system <azimuth_blade_coord>`')
+        self.add_input('blade_presweepTip', val=0.0, units='m', desc='location of blade pitch axis in y-direction at the tip (analogous to Rtip)')
+        # Airfoils
+        self.add_discrete_input("airfoils_name", val=n_af * [""], desc="1D array of names of airfoils.")
+        self.add_input("airfoils_position", val=np.zeros(n_af_span), desc="1D array of the non dimensional positions of the airfoils af_used defined along blade span.")
+        self.add_input("airfoils_r_thick", val=np.zeros(n_af), desc="1D array of the relative thicknesses of each airfoil.")
+        self.add_input("airfoils_aoa", val=np.zeros(n_aoa), units="rad", desc="1D array of the angles of attack used to define the polars of the airfoils. All airfoils defined in openmdao share this grid.")
+        self.add_input("airfoils_cl", val=np.zeros((n_af, n_aoa, n_Re, n_tab)), desc="4D array with the lift coefficients of the airfoils. Dimension 0 is along the different airfoils defined in the yaml, dimension 1 is along the angles of attack, dimension 2 is along the Reynolds number, dimension 3 is along the number of tabs, which may describe multiple sets at the same station, for example in presence of a flap.")
+        self.add_input("airfoils_cd", val=np.zeros((n_af, n_aoa, n_Re, n_tab)), desc="4D array with the drag coefficients of the airfoils. Dimension 0 is along the different airfoils defined in the yaml, dimension 1 is along the angles of attack, dimension 2 is along the Reynolds number, dimension 3 is along the number of tabs, which may describe multiple sets at the same station, for example in presence of a flap.")
+        self.add_input("airfoils_cm", val=np.zeros((n_af, n_aoa, n_Re, n_tab)), desc="4D array with the moment coefficients of the airfoils. Dimension 0 is along the different airfoils defined in the yaml, dimension 1 is along the angles of attack, dimension 2 is along the Reynolds number, dimension 3 is along the number of tabs, which may describe multiple sets at the same station, for example in presence of a flap.")
+        self.add_input("rotor_powercurve_v", val=np.zeros(n_pc), units="m/s", desc="wind vector")
+        self.add_input("rotor_powercurve_omega_rpm", val=np.zeros(n_pc), units="rpm", desc="rotor rotational speed")
+        self.add_input("rotor_powercurve_pitch", val=np.zeros(n_pc), units="deg", desc="rotor pitch schedule")
+        self.add_input("rho_air", val=1.225, units="kg/m**3", desc="Density of air")
+        self.add_input("mu_air", val=1.81e-5, units="kg/(m*s)", desc="Dynamic viscosity of air")
+        self.add_input("shear_exp", val=0.2, desc="Shear exponent of the wind.")
+        
         # member inputs
         for i in range(1, nmembers + 1):
 
@@ -184,32 +225,6 @@ class RAFT_OMDAO(om.ExplicitComponent):
             self.add_input(lt_name+'transverse_drag', val=0.0, desc='Transverse drag')
             self.add_input(lt_name+'tangential_drag', val=0.0, desc='Tangential drag')
 
-        # turbine inputs to be added
-        # general
-        #  turbine['nBlades']         # number of blades
-        #  turbine['shaft_tilt'],     # (deg) shaft tilt...
-        #  turbine['precone'],          # (deg) hub precone angle
-        #  turbine['Zhub'],           # (m) hub height used for power-law wind profile.  U = Uref*(z/hubHt)**shearExp
-        #  turbine['Rhub'],           # (m) radius of hub
-        # blade inputs to be added
-        #  turbine['blade']['r'],                # (m) locations defining the blade along z-axis of blade coordinate system
-        #  turbine['blade']['chord'],            # (m) corresponding chord length at each section
-        #  turbine['blade']['theta'],            # (deg) corresponding :ref:`twist angle <blade_airfoil_coord>` at each section---positive twist decreases angle of attack.
-        #  turbine['blade']['Rtip'],             # (m) radius of tip
-        #  turbine['blade']['precurve'],         # (m) location of blade pitch axis in x-direction of :ref:`blade coordinate system <azimuth_blade_coord>`
-        #  turbine['blade']['precurveTip'],      # (m) location of blade pitch axis in x-direction at the tip (analogous to Rtip)
-        #  turbine['blade']['presweep'],         # (m) location of blade pitch axis in y-direction of :ref:`blade coordinate system <azimuth_blade_coord>`
-        #  turbine['blade']['presweepTip'],      # (m) location of blade pitch axis in y-direction at the tip (analogous to Rtip)
-        # airfoils data
-        #  turbine['airfoils']['Re'], 
-        #  turbine['airfoils']['cl_interp']
-        #  turbine['airfoils']['cd_interp']
-        #  turbine['airfoils']['cm_interp']
-        # Atmospheric boundary layer data
-        #  turbine['env']['rho'     ] = wt_init['environment']["air_density"] # [kg/m3] - density of air
-        #  turbine['env']['mu'      ] = wt_init['environment']["air_dyn_viscosity"] # [kg/(ms)] - dynamic viscosity of air
-        #  turbine['env']['shearExp'] = wt_init['environment']["shear_exp"] # [-] - shear exponent 
-
         # outputs
         # properties
         nballast = np.sum(member_npts_rho_fill)
@@ -274,20 +289,34 @@ class RAFT_OMDAO(om.ExplicitComponent):
         design['name'] = ['spiderfloat']
         design['comments'] = ['none']
         
-        design['potModMaster'] = int(modeling_opt['potModMaster'])
-        design['XiStart'] = float(modeling_opt['XiStart'])
-        design['nIter'] = int(modeling_opt['nIter'])
-        design['dlsMax'] = float(modeling_opt['dlsMax'])
+        design['settings'] = {}
+        design['settings']['XiStart'] = float(modeling_opt['XiStart'])
+        design['settings']['dlsMax'] = float(modeling_opt['dlsMax'])
+        design['settings']['min_freq'] = float(inputs['frequency_range'][0])
+        design['settings']['max_freq'] = float(inputs['frequency_range'][-1])
 
+        # Environment layer data
+        design['site'] = {}
+        design['site']['water_depth'] = float(inputs['mooring_water_depth'])
+        design['site']['rho_air'] = float(inputs['rho_air'])
+        design['site']['mu_air' ] = float(inputs['mu_air'])
+        design['site']['shearExp'] = float(inputs['shear_exp'])
+        
         # TODO: these float conversions are messy
+        # GB: OpenMDAO converts all variables, even scalar floats, into numpy arrays.  The other option is something like inputs['turbine_mRNA'][0]
+        # RNA properties
         design['turbine'] = {}
-        design['turbine']['mRNA'] = float(inputs['turbine_mRNA'])
-        design['turbine']['IxRNA'] = float(inputs['turbine_IxRNA'])
-        design['turbine']['IrRNA'] = float(inputs['turbine_IrRNA'])
-        design['turbine']['xCG_RNA'] = float(inputs['turbine_xCG_RNA'])
-        design['turbine']['hHub'] = float(inputs['turbine_hHub'])
-        design['turbine']['Fthrust'] = float(inputs['turbine_Fthrust'])
+        design['turbine']['mRNA']          = float(inputs['turbine_mRNA'])
+        design['turbine']['IxRNA']         = float(inputs['turbine_IxRNA'])
+        design['turbine']['IrRNA']         = float(inputs['turbine_IrRNA'])
+        design['turbine']['xCG_RNA']       = float(inputs['turbine_xCG_RNA'])
+        design['turbine']['hHub']          = float(inputs['turbine_hHub'])
+        design['turbine']['overhang']      = float(inputs['turbine_overhang'])
+        design['turbine']['Fthrust']       = float(inputs['turbine_Fthrust'])
         design['turbine']['yaw_stiffness'] = float(inputs['turbine_yaw_stiffness'])
+        design['turbine']['gear_ratio']    = float(inputs['gear_ratio'])
+
+        # Tower
         design['turbine']['tower'] = {}
         design['turbine']['tower']['name'] = 'tower'
         design['turbine']['tower']['type'] = 1
@@ -316,15 +345,57 @@ class RAFT_OMDAO(om.ExplicitComponent):
             design['turbine']['tower']['CaEnd'] = inputs['turbine_tower_CaEnd']
         design['turbine']['tower']['rho_shell'] = float(inputs['turbine_tower_rho_shell'])
 
-        design['turbine']['control'] = {}
-        design['turbine']['control']['PC_GS_Angles']    = inputs['rotor_PC_GS_angles']
-        design['turbine']['control']['PC_GS_Kp']        = inputs['rotor_PC_GS_Kp']
-        design['turbine']['control']['PC_GS_Ki']        = inputs['rotor_PC_GS_Ki']
-        design['turbine']['control']['Fl_Kp']           = float(inputs['rotor_Fl_Kp'])
-        design['turbine']['control']['I_drivetrain']    = float(inputs['rotor_inertia'])
+        # Blades and rotors
+        design['turbine']['nBlades']    = int(discrete_inputs['nBlades'])
+        design['turbine']['shaft_tilt'] = float(inputs['tilt'])
+        design['turbine']['precone']    = float(inputs['precone'])
+        design['turbine']['Zhub']       = float(inputs['wind_reference_height'])
+        design['turbine']['Rhub']       = float(inputs['hub_radius'])
+        design['turbine']['I_drivetrain']    = float(inputs['rotor_inertia'])
 
+        design['turbine']['blade'] = {}
+        design['turbine']['blade']['geometry']    = np.c_[inputs['blade_r'],
+                                                          inputs['blade_chord'],
+                                                          inputs['blade_theta'],
+                                                          inputs['blade_precurve'],
+                                                          inputs['blade_presweep']]
+        design['turbine']['blade']['Rtip']        = float(inputs['blade_Rtip'])
+        design['turbine']['blade']['precurveTip'] = float(inputs['blade_precurveTip'])
+        design['turbine']['blade']['presweepTip'] = float(inputs['blade_presweepTip'])
+        design['turbine']['blade']['airfoils']    = list(zip(inputs['airfoils_position'], turbine_opt['af_used_names']))
+        # airfoils data
+        n_af = turbine_opt['n_af']
+        design['turbine']['airfoils'] = [{}]*n_af
+        for i in range(n_af):
+            design['turbine']['airfoils'][i]['name'] = discrete_inputs['airfoils_name'][i]
+            design['turbine']['airfoils'][i]['relative_thickness'] = inputs['airfoils_r_thick'][i]
+            design['turbine']['airfoils'][i]['data'] = np.c_[inputs['airfoils_aoa'],
+                                                             inputs['airfoils_cl'][i,:,0,0],
+                                                             inputs['airfoils_cd'][i,:,0,0],
+                                                             inputs['airfoils_cm'][i,:,0,0]]
+
+        # Control
+        design['turbine']['pitch_control'] = {}
+        design['turbine']['pitch_control']['GS_Angles']    = inputs['rotor_PC_GS_angles']
+        design['turbine']['pitch_control']['GS_Kp']        = inputs['rotor_PC_GS_Kp']
+        design['turbine']['pitch_control']['GS_Ki']        = inputs['rotor_PC_GS_Ki']
+        design['turbine']['pitch_control']['Fl_Kp']        = float(inputs['rotor_Fl_Kp'])
+        design['turbine']['torque_control'] = {}
+        # TODO: NEED HELP FROM DANZ ON WHERE THESE SHOULD BE CONNECTED TO
+        design['turbine']['torque_control']['VS_KP'] = 0.0
+        design['turbine']['torque_control']['VS_KI'] = 0.0
+
+        # Operations
+        design['turbine']['wt_ops'] = {}
+        design['turbine']['wt_ops']['v'] = inputs['rotor_powercurve_v']
+        design['turbine']['wt_ops']['omega_op'] = inputs['rotor_powercurve_omega_rpm']
+        design['turbine']['wt_ops']['pitch_op'] = inputs['rotor_powercurve_pitch']
+        
+        # Platform members
         design['platform'] = {}
-        design['platform']['members'] = [dict() for i in range(nmembers)]
+        design['platform']['potModMaster'] = int(modeling_opt['potModMaster'])
+        design['platform']['nIter'] = int(modeling_opt['nIter'])
+        design['platform']['members'] = [{}]*nmembers
         for i in range(nmembers):
             m_name = f'platform_member{i+1}_'
             m_shape = member_shapes[i]
@@ -404,14 +475,14 @@ class RAFT_OMDAO(om.ExplicitComponent):
 
         design['mooring'] = {}
         design['mooring']['water_depth'] = inputs['mooring_water_depth']
-        design['mooring']['points'] = [dict() for i in range(nconnections)]
+        design['mooring']['points'] = [{}]*nconnections
         for i in range(0, nconnections):
             pt_name = f'mooring_point{i+1}_'
             design['mooring']['points'][i]['name'] = discrete_inputs[pt_name+'name']
             design['mooring']['points'][i]['type'] = discrete_inputs[pt_name+'type']
             design['mooring']['points'][i]['location'] = inputs[pt_name+'location']
 
-        design['mooring']['lines'] = [dict() for i in range(nlines)]
+        design['mooring']['lines'] = [{}]*nlines
         for i in range(0, nlines):
             ml_name = f'mooring_line{i+1}_'
             design['mooring']['lines'][i]['name'] = f'line{i+1}'
@@ -419,7 +490,7 @@ class RAFT_OMDAO(om.ExplicitComponent):
             design['mooring']['lines'][i]['endB'] = discrete_inputs[ml_name+'endB']
             design['mooring']['lines'][i]['type'] = discrete_inputs[ml_name+'type']
             design['mooring']['lines'][i]['length'] = inputs[ml_name+'length']
-        design['mooring']['line_types'] = [dict() for i in range(nline_types)]
+        design['mooring']['line_types'] = [{}]*nline_types
         for i in range(0, nline_types):
             lt_name = f'mooring_line_type{i+1}_'
             design['mooring']['line_types'][i]['name'] = discrete_inputs[lt_name+'name']
@@ -433,21 +504,18 @@ class RAFT_OMDAO(om.ExplicitComponent):
             design['mooring']['line_types'][i]['transverse_drag'] = float(inputs[lt_name+'transverse_drag'])
             design['mooring']['line_types'][i]['tangential_drag'] = float(inputs[lt_name+'tangential_drag'])
 
-        # grab the depth
-        depth = float(design['mooring']['water_depth'])
-
-        # set up frequency range for computing response over
-        w = inputs['frequency_range']
-
         # create and run the model
-        model = raft.Model(design, w=w, depth=depth)
-        model.setEnv(spectrum="unit")
-        model.calcSystemProps()
-        model.solveEigen()
-        model.calcMooringAndOffsets()
-        model.solveDynamics()
+        model = raft.Model(design)
+        model.analyzeUnloaded()
+        model.analyzeCases()
+        # GB: Seems like RAFT doesn't run cases like this anymore?
+        #model.setEnv(spectrum="unit")
+        #model.calcSystemProps()
+        #model.solveEigen()
+        #model.calcMooringAndOffsets()
+        #model.solveDynamics()
         results = model.calcOutputs()
-
+        
         outs = self.list_outputs(values=False, out_stream=None)
         for i in range(len(outs)):
             if outs[i][0].startswith('properties_'):

--- a/raft/raft_model.py
+++ b/raft/raft_model.py
@@ -1,8 +1,6 @@
 # RAFT's main model class
 
 import os
-import os.path as osp
-import sys
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import cm
@@ -54,7 +52,7 @@ class Model():
         self.XiStart = getFromDict(design['settings'], 'XiStart' , default=0.1 , dtype=float)  # sets initial amplitude of each DOF for all frequencies
         self.nIter   = getFromDict(design['settings'], 'nIter'   , default=15  , dtype=int  )  # sets how many iterations to perform in Model.solveDynamics()
         
-        self.w = np.arange(min_freq, max_freq, min_freq) *2*np.pi  # angular frequencies to analyze (rad/s)
+        self.w = np.arange(min_freq, max_freq+0.5*min_freq, min_freq) *2*np.pi  # angular frequencies to analyze (rad/s)
         self.nw = len(self.w)  # number of frequencies
                 
         
@@ -152,7 +150,7 @@ class Model():
         
             # form dictionary of case parameters
             case = dict(zip( self.design['cases']['keys'], self.design['cases']['data'][iCase]))   
-    
+
             # get initial FOWT values assuming no offset
             for fowt in self.fowtList:
                 fowt.Xi0 = np.zeros(6)      # zero platform offsets

--- a/raft/raft_model.py
+++ b/raft/raft_model.py
@@ -54,7 +54,8 @@ class Model():
         
         self.w = np.arange(min_freq, max_freq+0.5*min_freq, min_freq) *2*np.pi  # angular frequencies to analyze (rad/s)
         self.nw = len(self.w)  # number of frequencies
-                
+        if self.nw == 0:
+            raise ValueError(f"No frequencies to run in RAFT between {min_freq} and {max_freq}")
         
         # process mooring information 
         self.ms = mp.System()

--- a/raft/raft_rotor.py
+++ b/raft/raft_rotor.py
@@ -147,7 +147,9 @@ class Rotor:
         # https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.PchipInterpolator.derivative.html#scipy.interpolate.PchipInterpolator.derivative
         spline = PchipInterpolator
         rthick_spline = spline(af_position, r_thick_used)
-        r_thick_interp = rthick_spline(grid[1:-1])
+        # GB: HAVE TO TALK TO PIETRO ABOUT THIS
+        #r_thick_interp = rthick_spline(grid[1:-1])
+        r_thick_interp = rthick_spline(grid)
 
         # Spanwise interpolation of the airfoil polars with a pchip
         r_thick_unique, indices = np.unique(r_thick_used, return_index=True)
@@ -168,12 +170,9 @@ class Rotor:
         blade_precurve  = geometry_table[:,3]
         blade_presweep  = geometry_table[:,4]
         
-        
-        
         af = []
         for i in range(self.cl_interp.shape[0]):
             af.append(CCAirfoil(self.aoa, [], self.cl_interp[i,:,:],self.cd_interp[i,:,:],self.cm_interp[i,:,:]))
-        
         
         self.ccblade = CCBlade(
             blade_r,                        # (m) locations defining the blade along z-axis of blade coordinate system

--- a/raft/raft_rotor.py
+++ b/raft/raft_rotor.py
@@ -1,16 +1,14 @@
 # RAFT's rotor class
 
 import os
-import os.path as osp
-import sys, yaml
+import yaml
 import numpy as np
 import matplotlib.pyplot as plt
 
 from scipy.interpolate import PchipInterpolator
 
-from helpers import deg2rad, rotationMatrix
+from raft.helpers import rotationMatrix
 
-import wisdem.inputs as sch
 from wisdem.ccblade.ccblade import CCBlade, CCAirfoil
 
 '''
@@ -222,8 +220,8 @@ class Rotor:
         pitch_deg = np.interp(Uhub, self.Uhub, self.pitch_deg)  # blade pitch angle [deg]
         
         # adjust rotor angles based on provided info (I think this intervention in CCBlade should work...)
-        self.ccblade.tilt = deg2rad(self.shaft_tilt) + ptfm_pitch
-        self.ccblade.yaw  = deg2rad(yaw_misalign)
+        self.ccblade.tilt = np.deg2rad(self.shaft_tilt) + ptfm_pitch
+        self.ccblade.yaw  = np.deg2rad(yaw_misalign)
         
         # evaluate aero loads and derivatives with CCBlade
         loads, derivs = self.ccblade.evaluate(Uhub, Omega_rpm, pitch_deg, coefficients=True)
@@ -474,7 +472,7 @@ class Rotor:
         # (blade pitch would be a -rotation about local z)
         R_precone = rotationMatrix(0, -self.ccblade.precone, 0)  
         R_azimuth = [rotationMatrix(azimuth + azi, 0, 0) for azi in 2*np.pi/3.*np.arange(3)]
-        R_tilt    = rotationMatrix(0, deg2rad(self.shaft_tilt), 0)   # # define x as along shaft downwind, y is same as ptfm y
+        R_tilt    = rotationMatrix(0, np.deg2rad(self.shaft_tilt), 0)   # # define x as along shaft downwind, y is same as ptfm y
         
         # ----- transform coordinates -----
         for ib in range(3):


### PR DESCRIPTION
These changes allow WEIS to automatically call RAFT and execute the rotor analysis with the DLC case structure.  Some changes should definitely be reviewed by the RAFT team.  I would also recommend activating a CI around a set of unit and regression tests to ensure the interoperability doesn't lapse.