### PR TITLE
Lean on HAMS calculation of 0 and inf freqs

### DIFF
--- a/raft/omdao_raft.py
+++ b/raft/omdao_raft.py
@@ -528,7 +528,7 @@ class RAFT_OMDAO(om.ExplicitComponent):
         #model.solveDynamics()
         results = model.calcOutputs()
         
-        outs = self.list_outputs(values=False, out_stream=None)
+        outs = self.list_outputs(val=False, out_stream=None)
         for i in range(len(outs)):
             if outs[i][0].startswith('properties_'):
                 name = outs[i][0].split('properties_')[1]

--- a/raft/raft_model.py
+++ b/raft/raft_model.py
@@ -597,24 +597,6 @@ class Model():
         return self.results
         
 
-    def preprocess_HAMS(self, FAST_outname, dw=0, wMax=0):
-        '''This generates a mesh for the platform, runs a BEM analysis on it
-        using pyHAMS, and writes .1 and .3 output files for use with OpenFAST.
-        The mesh is only made for non-interesecting members flagged with potMod=1.
-        
-        PARAMETERS
-        ----------
-        FAST_outname : string
-            The full path and file name (minus extension) for the .1 and .3 files to be written to.
-        dw : float
-            Optional specification of custom frequency increment (rad/s).
-        wMax : float
-            Optional specification of maximum frequency for BEM analysis (rad/s). Will only be
-            used if it is greater than the maximum frequency used in RAFT.
-        '''
-        
-        self.fowtList[0].calcBEM(FAST_outname=FAST_outname, dw=dw, wMax=wMax)
-
 
     def plot(self, hideGrid=False):
         '''plots the whole model, including FOWTs and mooring system...'''

--- a/raft/raft_rotor.py
+++ b/raft/raft_rotor.py
@@ -14,7 +14,7 @@ from scipy.interpolate      import PchipInterpolator
 from scipy.special          import modstruve, iv
 
 
-from helpers                import deg2rad, rotationMatrix
+from raft.helpers                import rotationMatrix
 
 from wisdem.ccblade.ccblade import CCBlade, CCAirfoil
 


### PR DESCRIPTION
This undoes some of Matt's recent changes (sorry Matt) that served as a bandaid until HAMS computed the zero and infinite frequencies on its own.  It also leans on pyHAMS more to simply pass the vector of frequencies instead of figuring out the right regular interval to use.  To use these updates, you will also need to update pyHAMS.