### PR TITLE
Fix Rotor/Blade Units

### DIFF
--- a/raft/raft_fowt.py
+++ b/raft/raft_fowt.py
@@ -758,27 +758,38 @@ class FOWT():
         results['Mbase_std'][iCase] = dynamic_moment_RMS
         #results['Mbase_max'][iCase]
         #results['Mbase_DEL'][iCase]
-        '''
-        # rotor speed
-        results['omega_avg'][iCase]    
-        results['omega_std'][iCase]    
-        results['omega_max'][iCase]      
+
+       
+        # rotor speed (rpm)
+        # spectra
+        phi_w   = self.rotor.C * (XiHub - self.rotor.V_w / (1j *self.w))
+        omega_w =  (1j *self.w) * phi_w
+
+        results['omega_avg'][iCase]     = self.rotor.Omega_case
+        results['omega_std'][iCase]     = radps2rpm(getRMS(omega_w))
+        results['omega_max'][iCase]     = results['omega_avg'][iCase] + 2 * results['omega_std'][iCase] # this and other _max values will be based on std (avg + 2 or 3 * std)   (95% or 99% max)
         
-        # generator torque
-        results['torque_avg'][iCase]
-        results['torque_std'][iCase] 
-        results['torque_max'][iCase]    
+        # generator torque (Nm)
+        torque_w = (1j * self.w * self.rotor.kp_tau + self.rotor.ki_tau) * phi_w
+
+        results['torque_avg'][iCase]    = self.rotor.aero_torque / self.rotor.Ng        # Nm
+        results['torque_std'][iCase]    = getRMS(torque_w)
+        # results['torque_max'][iCase]    # skip, nonlinear
         
-        # rotor power 
-        results['power_avg'][iCase]
-        results['power_std'][iCase]
-        results['power_max'][iCase]
         
-        # collective blade pitch
-        results['bPitch_avg'][iCase]
-        results['bPitch_std'][iCase]   
-        results['bPitch_max'][iCase]  
-        '''
+        # rotor power (W)
+        results['power_avg'][iCase]    = self.rotor.aero_power # compute from cc-blade coeffs
+        # results['power_std'][iCase]     # nonlinear near rated, covered by torque_ and omega_std
+        # results['power_max'][iCase]     # skip, nonlinear
+
+        
+        # collective blade pitch (deg)
+        bPitch_w = (1j * self.w * self.rotor.kp_beta + self.rotor.ki_beta) * phi_w
+
+        results['bPitch_avg'][iCase]    = self.rotor.pitch_case
+        results['bPitch_std'][iCase]    = rad2deg(getRMS(bPitch_w))
+        # results['bPitch_max'][iCase]    # skip, not something we'd consider in design
+
 
         '''
         Outputs from OpenFAST to consider covering:

--- a/raft/raft_rotor.py
+++ b/raft/raft_rotor.py
@@ -52,21 +52,10 @@ class Rotor:
         self.R_rot      = turbine['blade']['Rtip']  # rotor radius [m]
         #yaw  = 0        
 
-        # Set some turbine params, this can come from WEIS/WISDEM or an external input
-        if old:
-            self.rot_from_weis = yaml.load(open(os.path.join(raft_dir,'designs/rotors/IEA-15MW_WEIS.yaml'),'r'))
-            self.Uhub = np.array(self.rot_from_weis['wt_ops']['v'])
-            self.Omega_rpm = np.array(self.rot_from_weis['wt_ops']['omega_op']) / rpm2radps
-            self.pitch_deg = np.array(self.rot_from_weis['wt_ops']['pitch_op']) * rad2deg
-            self.I_drivetrain = 3.2e8
-        else:   # planning on this option going forward
-            #self.Uhub = np.array([14.])
-            #self.Omega_rpm = np.array([7.56])
-            #self.pitch_deg = np.array([13.78])
-            self.Uhub      = np.array(turbine['wt_ops']['v'])
-            self.Omega_rpm = np.array(turbine['wt_ops']['omega_op']) / rpm2radps
-            self.pitch_deg = np.array(turbine['wt_ops']['pitch_op']) * rad2deg
-            self.I_drivetrain = float(turbine['I_drivetrain'])
+        self.Uhub      = np.array(turbine['wt_ops']['v'])
+        self.Omega_rpm = np.array(turbine['wt_ops']['omega_op'])
+        self.pitch_deg = np.array(turbine['wt_ops']['pitch_op'])
+        self.I_drivetrain = float(turbine['I_drivetrain'])
 
 
         # Set default control gains

--- a/raft/raft_rotor.py
+++ b/raft/raft_rotor.py
@@ -239,6 +239,12 @@ class Rotor:
         loads, derivs = self.ccblade.evaluate(Uhub, Omega_rpm, pitch_deg, coefficients=True)
 
         # organize and save the relevant outputs...
+        self.U_case         = Uhub
+        self.Omega_case     = Omega_rpm
+        self.aero_torque    = loads["Q"][0]
+        self.aero_power     = loads["P"][0]
+        self.pitch_case     = pitch_deg
+
         outputs = {}
         
         outputs["P"] = loads["P"]
@@ -392,12 +398,12 @@ class Rotor:
         dQ_dPi = np.atleast_1d(np.diag(derivs["dQ"]["dpitch"])) * rad2deg
 
         # Pitch control gains at Uinf (Uinf), flip sign to translate ROSCO convention to this one
-        kp_U    = -np.interp(Uinf, self.Uhub, self.kp_0) 
-        ki_U    = -np.interp(Uinf, self.Uhub, self.ki_0) 
+        self.kp_beta    = -np.interp(Uinf, self.Uhub, self.kp_0) 
+        self.ki_beta    = -np.interp(Uinf, self.Uhub, self.ki_0) 
 
         # Torque control gains, need to get these from somewhere
-        kp_tau = self.kp_tau * (kp_U == 0)  #     -38609162.66552     ! VS_KP				- Proportional gain for generator PI torque controller [1/(rad/s) Nm]. (Only used in the transitional 2.5 region if VS_ControlMode =/ 2)
-        ki_tau = self.kp_tau  * (kp_U == 0)   #    -4588245.18720      ! VS_KI	
+        kp_tau = self.kp_tau * (self.kp_beta == 0)  #     -38609162.66552     ! VS_KP				- Proportional gain for generator PI torque controller [1/(rad/s) Nm]. (Only used in the transitional 2.5 region if VS_ControlMode =/ 2)
+        ki_tau = self.kp_tau  * (self.kp_beta == 0)   #    -4588245.18720      ! VS_KI	
         
         a_aer = np.zeros_like(self.w)
         b_aer = np.zeros_like(self.w)
@@ -407,19 +413,19 @@ class Rotor:
         E   = np.zeros_like(self.w,dtype=np.complex_)
 
         # Roots of characteristic equation, helps w/ debugging
-        p = np.array([-self.I_drivetrain, (dQ_dOm + kp_U * dQ_dPi - self.Ng * kp_tau), ki_U* dQ_dPi - self.Ng * ki_tau])
+        p = np.array([-self.I_drivetrain, (dQ_dOm + self.kp_beta * dQ_dPi - self.Ng * kp_tau), self.ki_beta* dQ_dPi - self.Ng * ki_tau])
         r = np.roots(p)
 
         for iw, omega in enumerate(self.w):
             
             # Denominator of control transfer function
-            D[iw] = self.I_drivetrain * omega**2 + (dQ_dOm + kp_U * dQ_dPi - self.Ng * kp_tau) * 1j * omega + ki_U* dQ_dPi - self.Ng * ki_tau
+            D[iw] = self.I_drivetrain * omega**2 + (dQ_dOm + self.kp_beta * dQ_dPi - self.Ng * kp_tau) * 1j * omega + self.ki_beta* dQ_dPi - self.Ng * ki_tau
 
             # control transfer function
             C[iw] = 1j * omega * (dQ_dU - self.k_float * dQ_dPi / self.Zhub) / D[iw]
 
             # Thrust transfer function
-            E[iw] = ((dT_dOm + kp_U * dT_dPi) * 1j * omega + ki_U * dT_dPi )
+            E[iw] = ((dT_dOm + self.kp_beta * dT_dPi) * 1j * omega + self.ki_beta * dT_dPi )
 
             # alternative for debugging
             C2[iw] = C[iw] / (1j * omega)
@@ -431,19 +437,8 @@ class Rotor:
             a_aer[iw] = -(1/omega**2) * np.real(T)
             b_aer[iw] = (1/omega) * np.imag(T)
         
-        '''
-        # coefficients to be filled in
-        nw = len(self.w)
-        A_aero = np.zeros([6,6,nw])                     # added mass
-        B_aero = np.zeros([6,6,nw])                     # damping
-        C_aero = np.zeros([6,6])                        # stiffness
-        F_aero0= np.zeros(6)                            # steady wind forces/moments
-        F_aero = np.zeros([6,nw])                       # wind excitation spectra in each DOF
-        
-        # calculate contribution to system matrices      
-        A_aero[0,0,:] = a_aer
-        B_aero[0,0,:] = b_aer
-        '''
+        # Save transfer functions required for output
+        self.C = C
                 
         # calculate steady aero forces and moments
         F_aero0 = np.array([loads["T" ][0], loads["Y"  ][0], loads["Z"  ][0],
@@ -452,16 +447,16 @@ class Rotor:
         # calculate wind excitation force/moment spectra
         _,_,_,S_rot = self.IECKaimal(case)
 
-        V_w = np.sqrt(S_rot)
+        self.V_w = S_rot
         T_0 = loads["T" ][0]
-        T_w1 = dT_dU * V_w
-        T_w2 = (E * C * V_w) / (1j * self.w)
+        T_w1 = dT_dU * self.V_w
+        T_w2 = (E * C * self.V_w) / (1j * self.w)
 
         T_ext = T_w1 + T_w2
 
         # print('here')
         if False:
-            plt.plot(self.w, V_w, label = 'S_rot')
+            plt.plot(self.w, self.V_w, label = 'S_rot')
             plt.yscale('log')
             plt.xscale('log')
 
@@ -476,7 +471,7 @@ class Rotor:
             plt.plot(self.w, np.abs(T_ext))
             # plt.plot(self.w, abs(T_w2))
 
-            plt.show()
+            # plt.show()
 
         f_aero = T_ext  # wind thrust force excitation spectrum
         
@@ -690,7 +685,7 @@ if __name__=='__main__':
         for iU, Uinf in enumerate(UU):
             # rr.V = Uinf
             case['wind_speed'] = Uinf
-            _,_,_,_,_, a_aer, b_aer = rr.calcAeroServoContributions(case)
+            _,_, a_aer, b_aer = rr.calcAeroServoContributions(case)
 
             a_aer_U[iU] = np.interp(2 * np.pi / 30, rr.w, a_aer)
             b_aer_U[iU] = np.interp(2 * np.pi / 30, rr.w, b_aer)
@@ -701,16 +696,20 @@ if __name__=='__main__':
 
 
         ax1[0].plot(UU,a_aer_U)
-        ax1[0].set_ylabel('a_aer @ 30 sec.')
+        ax1[0].set_ylabel('$a_\mathrm{aer}$ @ 30 sec.\n(kg)')
         ax1[0].grid(True)
 
         ax1[1].plot(UU,b_aer_U)
-        ax1[1].set_ylabel('b_aer @ 30 sec.')
+        ax1[1].set_ylabel('$b_\mathrm{aer}$ @ 30 sec.\n(Ns/m)')
         ax1[1].grid(True)
 
-        ax1[1].set_xlabel('U (m/s)')
+        ax1[1].set_xlabel('Wind Speed (m/s)')
 
-    plt.show()
+        plt.ticklabel_format(axis='y',style='sci',scilimits=(0,0))
+
+        fig1.align_ylabels()
+
+    plt.savefig('/Users/dzalkind/Projects/WEIS/Docs/Level1/rotor_mass_damp.pdf',format='pdf')
 
 
     # ax1[0].plot(ww,a_aer)


### PR DESCRIPTION
I have been having some issues running [this example](https://github.com/WISDEM/WEIS/blob/develop/examples/06_IEA-15-240-RWT/weis_driver_umaine_semi.py) in WEIS.

I think part of the issue is that these units are incorrect when the information comes from WEIS, but it seems like the `ccblade` calculations are still off (negative or > 1 Cp) or returning NaNs.  I've tried tracking down the error, but @gbarter and @PB (not on this repo!) might be better at tracking this down.  I'll reach out for some more help, but I just wanted to put this on folk's radars, for now.

Also, the version of RAFT on WEIS is a little behind this current dev.  Maybe this is a good chance for us to get the latest into WEIS.  Let's leave this open until we figure out the units around cc-blade.

P.S., it looks like some output calculations were also included here.