### PR TITLE
Modify Member.getHydrostatics

### DIFF
--- a/raft/raft_member.py
+++ b/raft/raft_member.py
@@ -828,8 +828,8 @@ class Member:
                 My = M*dPhi_dThy
 
                 Fvec[2] += Fz                           # vertical buoyancy force [N]
-                Fvec[3] += Mx + Fz*rA[1]                # moment about x axis [N-m]
-                Fvec[4] += My - Fz*rA[0]                # moment about y axis [N-m]
+                Fvec[3] += Mx + Fz*r_center[1]                # moment about x axis [N-m]
+                Fvec[4] += My - Fz*r_center[0]                # moment about y axis [N-m]
 
 
                 # normal approach to hydrostatic stiffness, using this temporarily until above fancier approach is verified


### PR DESCRIPTION
Small corrections to Member.getHydrostatics in evaluation of cross section area/moment of inertia, and the point which Fvec acts on

## Purpose
1. A more accurate method to evaluate the cross-sectional area and moment of inertia of a member clipped by the waterplane, since the clipped area is no longer a circle or the original rectangular but an ellipse or a projection of rectangular.

2. moment about A end changed to about buoyancy center of segment: r_center

## Type of change
What types of change is it?
_Select the appropriate type(s) that describe this PR_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (non-backwards-compatible fix or feature)
- [ ] Code style update (formatting, renaming)
- [√] Refactoring (no functional changes, no API changes)
- [ ] Documentation update
- [ ] Maintenance update
- [ ] Other (please describe)

## Testing
It seems that hydrostatic test data used for testing is not very good, the results are only tested in my own code with the aid of meshmagic (https://github.com/LHEEA/meshmagick).

## Checklist
_Put an `x` in the boxes that apply._

- [x] I have run existing tests which pass locally with my changes
- [ ] I have added new tests or examples that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation